### PR TITLE
feat: add peakroute alias command for external services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Features
 
+- **`peakroute alias` command**: Register routes for external services not spawned by peakroute (e.g., Docker containers with published ports). Aliases use `pid=0` as a sentinel and are never cleaned up as stale.
+
+  ```bash
+  # Register an external service
+  peakroute alias mydocker.localhost 8080
+
+  # Remove an alias
+  peakroute alias remove mydocker.localhost
+
+  # List shows [external] indicator
+  peakroute list
+  # http://mydocker.localhost:1355 -> localhost:8080 (pid 0) [external]
+  ```
+
 - **`PEAKROUTE_URL` environment variable**: Child processes now receive `PEAKROUTE_URL` containing the public `.localhost` URL (e.g., `http://myapp.localhost:1355`). This allows apps to self-reference without hardcoding the URL.
 
 - **`--app-port` flag and `PEAKROUTE_APP_PORT` environment variable**: Specify a specific port for your app instead of auto-finding one. Useful when your app needs a fixed port.

--- a/packages/peakroute/README.md
+++ b/packages/peakroute/README.md
@@ -123,6 +123,8 @@ sudo peakroute trust
 peakroute <name> <cmd> [args...]  # Run app at http://<name>.localhost:1355
 peakroute list                    # Show active routes
 peakroute trust                   # Add local CA to system trust store
+peakroute alias <host> <port>    # Register external service (e.g., Docker)
+peakroute alias remove <host>     # Remove an external route
 
 # Disable peakroute (run command directly)
 PEAKROUTE=0 bun dev              # Bypasses proxy, uses default port
@@ -163,6 +165,27 @@ Peakroute stores its state (routes, PID file, port file) in a directory that dep
 - **Port >= 1024** (no sudo): `~/.peakroute` -- user-scoped, no root involvement
 
 Override with the `PEAKROUTE_STATE_DIR` environment variable if needed.
+
+## External Services (Docker, etc.)
+
+Use the `peakroute alias` command to register routes for services not spawned by peakroute, such as Docker containers or other external processes:
+
+```bash
+# Register a Docker container running on port 3000
+peakroute alias mydocker.localhost 3000
+
+# Now access it at http://mydocker.localhost:1355
+
+# Remove the alias when done
+peakroute alias remove mydocker.localhost
+```
+
+Aliases are marked with `[external]` in the route list and are never cleaned up as "stale" since they don't have an associated process PID.
+
+```bash
+peakroute list
+# -> http://mydocker.localhost:1355 -> localhost:3000 (pid 0) [external]
+```
 
 ## Development
 

--- a/packages/peakroute/src/cli.ts
+++ b/packages/peakroute/src/cli.ts
@@ -348,8 +348,9 @@ function listRoutes(store: RouteStore, proxyPort: number, tls: boolean): void {
   console.log(chalk.blue.bold("\nActive routes:\n"));
   for (const route of routes) {
     const url = formatUrl(route.hostname, proxyPort, tls);
+    const externalIndicator = route.pid === 0 ? chalk.gray(" [external]") : "";
     console.log(
-      `  ${chalk.cyan(url)}  ${chalk.gray("->")}  ${chalk.white(`localhost:${route.port}`)}  ${chalk.gray(`(pid ${route.pid})`)}`
+      `  ${chalk.cyan(url)}  ${chalk.gray("->")}  ${chalk.white(`localhost:${route.port}`)}  ${chalk.gray(`(pid ${route.pid})`)}${externalIndicator}`
     );
   }
   console.log();
@@ -590,6 +591,8 @@ ${chalk.bold("Usage:")}
   ${chalk.cyan("peakroute <name> <cmd>")}            Run your app through the proxy
   ${chalk.cyan("peakroute list")}                    Show active routes
   ${chalk.cyan("peakroute trust")}                   Add local CA to system trust store
+  ${chalk.cyan("peakroute alias \u003chost\u003e \u003cport\u003e")}    Register a route for external services (e.g. Docker)
+  ${chalk.cyan("peakroute alias remove \u003chost\u003e")}     Remove an external route
 
 ${chalk.bold("Examples:")}
   peakroute proxy start                # Start proxy on port 1355
@@ -677,6 +680,62 @@ ${chalk.bold("Skip peakroute:")}
       onWarning: (msg) => console.warn(chalk.yellow(msg)),
     });
     listRoutes(store, port, tls);
+    return;
+  }
+
+  // Alias commands (for external services like Docker)
+  if (args[0] === "alias") {
+    const { dir } = await discoverState();
+    const store = new RouteStore(dir, {
+      onWarning: (msg) => console.warn(chalk.yellow(msg)),
+    });
+
+    if (args[1] === "remove") {
+      const hostname = args[2];
+      if (!hostname) {
+        console.error(chalk.red("Error: Missing hostname."));
+        console.error(chalk.blue("Usage:"));
+        console.error(chalk.cyan("  peakroute alias remove <hostname>"));
+        process.exit(1);
+      }
+      try {
+        store.removeRoute(parseHostname(hostname));
+        console.log(chalk.green(`Alias removed: ${hostname}`));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(chalk.red(`Failed to remove alias: ${message}`));
+        process.exit(1);
+      }
+      return;
+    }
+
+    // Add alias: peakroute alias <hostname> <port>
+    const hostname = args[1];
+    const portStr = args[2];
+
+    if (!hostname || !portStr) {
+      console.error(chalk.red("Error: Missing arguments."));
+      console.error(chalk.blue("Usage:"));
+      console.error(chalk.cyan("  peakroute alias <hostname> <port>"));
+      console.error(chalk.cyan("  peakroute alias remove <hostname>"));
+      process.exit(1);
+    }
+
+    const portNum = parseInt(portStr, 10);
+    if (isNaN(portNum) || portNum < 1 || portNum > 65535) {
+      console.error(chalk.red(`Error: Invalid port number: ${portStr}`));
+      console.error(chalk.blue("Port must be between 1 and 65535."));
+      process.exit(1);
+    }
+
+    try {
+      store.addAlias(parseHostname(hostname), portNum);
+      console.log(chalk.green(`Alias registered: ${hostname} -> localhost:${portNum}`));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(chalk.red(`Failed to register alias: ${message}`));
+      process.exit(1);
+    }
     return;
   }
 

--- a/packages/peakroute/src/routes.test.ts
+++ b/packages/peakroute/src/routes.test.ts
@@ -226,4 +226,48 @@ describe("RouteStore", () => {
       expect(routes[0].hostname).toBe("test.localhost");
     });
   });
+
+  describe("addAlias", () => {
+    it("registers route with pid=0 (external/persistent)", () => {
+      store.addAlias("docker.localhost", 8080);
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0]).toEqual({
+        hostname: "docker.localhost",
+        port: 8080,
+        pid: 0,
+      });
+    });
+
+    it("preserves pid=0 routes during stale cleanup", () => {
+      store.addAlias("docker.localhost", 8080);
+      // Load with persistCleanup=true should still keep pid=0 routes
+      const routes = store.loadRoutes(true);
+      expect(routes).toHaveLength(1);
+      expect(routes[0].hostname).toBe("docker.localhost");
+    });
+
+    it("throws when hostname already exists", () => {
+      store.addAlias("docker.localhost", 8080);
+      expect(() => store.addAlias("docker.localhost", 9090)).toThrow(
+        'Hostname "docker.localhost" is already registered'
+      );
+    });
+
+    it("allows multiple aliases with different hostnames", () => {
+      store.addAlias("docker1.localhost", 8080);
+      store.addAlias("docker2.localhost", 9090);
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(2);
+      const ports = routes.map((r) => r.port).sort();
+      expect(ports).toEqual([8080, 9090]);
+    });
+
+    it("can be removed with removeRoute", () => {
+      store.addAlias("docker.localhost", 8080);
+      store.removeRoute("docker.localhost");
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(0);
+    });
+  });
 });

--- a/packages/peakroute/src/routes.ts
+++ b/packages/peakroute/src/routes.ts
@@ -171,6 +171,9 @@ export class RouteStore {
    * is no longer alive. Stale-route cleanup is only persisted when the caller
    * already holds the lock (i.e. inside addRoute/removeRoute) to avoid
    * unprotected concurrent writes.
+   *
+   * Note: Routes with pid=0 are considered external (e.g., Docker containers)
+   * and are never filtered out as stale.
    */
   loadRoutes(persistCleanup = false): RouteMapping[] {
     if (!fs.existsSync(this.routesPath)) {
@@ -191,7 +194,8 @@ export class RouteStore {
       }
       const routes: RouteMapping[] = parsed.filter(isValidRoute);
       // Filter out stale routes whose owning process is no longer alive
-      const alive = routes.filter((r) => this.isProcessAlive(r.pid));
+      // pid=0 is a sentinel for external routes (e.g., Docker) - never stale
+      const alive = routes.filter((r) => r.pid === 0 || this.isProcessAlive(r.pid));
       if (persistCleanup && alive.length !== routes.length) {
         // Persist the cleaned-up list so stale entries don't accumulate.
         // Only safe when caller holds the lock.
@@ -240,6 +244,29 @@ export class RouteStore {
     }
     try {
       const routes = this.loadRoutes(true).filter((r) => r.hostname !== hostname);
+      this.saveRoutes(routes);
+    } finally {
+      this.releaseLock();
+    }
+  }
+
+  /**
+   * Register an alias for an external service (e.g., Docker container).
+   * Uses pid=0 as a sentinel to indicate the route is not managed by
+   * a child process and should never be cleaned up as "stale".
+   */
+  addAlias(hostname: string, port: number): void {
+    this.ensureDir();
+    if (!this.acquireLock()) {
+      throw new Error("Failed to acquire route lock");
+    }
+    try {
+      const routes = this.loadRoutes(true);
+      const existing = routes.find((r) => r.hostname === hostname);
+      if (existing) {
+        throw new Error(`Hostname "${hostname}" is already registered`);
+      }
+      routes.push({ hostname, port, pid: 0 }); // pid=0 = external
       this.saveRoutes(routes);
     } finally {
       this.releaseLock();


### PR DESCRIPTION
- Add addAlias() method to RouteStore with pid=0 sentinel
- Update listRoutes() to show [external] indicator for aliases
- Add alias command to CLI for registering/removing external routes
- Update help text with alias usage
- All 171 tests passing